### PR TITLE
fix(linux): allow application to exit when window is closed

### DIFF
--- a/app.js
+++ b/app.js
@@ -76,7 +76,7 @@ app.once('ready', () => {
       if (process.platform == 'darwin') {
         // app.hide();
         app.exit(0);
-      } else if (process.platform == 'linux') {
+      } else if (process.platform == 'linux') { app.exit(0);
         return;
       } else {
         mainWindow.hide();


### PR DESCRIPTION
On Linux, the application would prevent the window from closing but didn't provide a way to actually exit the app via the close button. This change ensures app.exit(0) is called when the close event is triggered on Linux.