### PR TITLE
fix(linux): allow application to exit when window is closed

### DIFF
--- a/app.js
+++ b/app.js
@@ -76,7 +76,7 @@ app.once('ready', () => {
       if (process.platform == 'darwin') {
         // app.hide();
         app.exit(0);
-      } else if (process.platform == 'linux') {
+      } else if (process.platform == 'linux') { app.exit(0);
         return;
       } else {
         mainWindow.hide();


### PR DESCRIPTION
### Problem | 问题描述

On Linux, the application prevents the window from closing by default but does not provide a mechanism to actually exit the process when the close button is clicked. This leads to the application becoming unresponsive to the close action and remaining in the background.

在 Linux 平台上，蚁剑源码默认拦截了窗口关闭事件，但未提供退出程序的逻辑。这导致用户点击关闭按钮时，窗口无法关闭且程序持续在后台运行，无法正常退出。

### Fix | 修复方案

Modified `app.js` to explicitly call `app.exit(0)` when the 'close' event is triggered on the Linux platform.

修改 `app.js`，在 Linux 平台的 `close` 事件回调中显式调用 `app.exit(0)`，确保程序能正常退出。

### Changes | 代码变更

```javascript
// app.js
mainWindow.on('close', (event) => {
    event.preventDefault();
    if (process.platform == 'darwin') {
      app.exit(0);
    } else if (process.platform == 'linux') {
      app.exit(0); // <--- Added this line | 增加此行
      return;
    }
```